### PR TITLE
Maintains old trove links

### DIFF
--- a/app/Models/Trove.php
+++ b/app/Models/Trove.php
@@ -260,4 +260,38 @@ class Trove extends Model implements HasMedia
 
         return MediaStream::create($filename)->addMedia($troveFiles);
     }
+
+    public static function findBySlugOrRedirect($troveKey): ?self
+    {
+        // Try slug
+        $trove = self::where('slug', $troveKey)
+            ->where('is_published', 1)
+            ->first();
+        if ($trove) return $trove;
+
+        // Try id
+        if (is_numeric($troveKey)) {
+            $trove = self::where('id', (int) $troveKey)
+                ->where('is_published', 1)
+                ->first();
+            if ($trove) return $trove;
+        }
+
+        // Try previous_slugs (string)
+        $trove = self::whereJsonContains('previous_slugs', (string) $troveKey)
+            ->where('is_published', 1)
+            ->first();
+        if ($trove) return $trove;
+
+        // Try previous_slugs (numeric)
+        if (is_numeric($troveKey)) {
+            $trove = self::whereJsonContains('previous_slugs', (int) $troveKey)
+                ->where('is_published', 1)
+                ->first();
+            if ($trove) return $trove;
+        }
+
+        return null;
+    }
+
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,10 +27,20 @@ Route::group([
         return view('components.home');
     })->name('home');
 
-    Route::get('/resources/{slug}', function ($slug) {
-        $resource = Trove::where('slug', $slug)->where('is_published', 1)->firstOrFail();
-        return view('trove', compact('resource'));
-    });
+    Route::get('/resources/{troveKey}', function ($troveKey) {
+        $resource = Trove::findBySlugOrRedirect($troveKey);
+    
+        if (! $resource) {
+            abort(404);
+        }
+    
+        // If slug doesn't match, redirect to correct slug
+        if ($resource->slug !== $troveKey) {
+            return redirect()->route('resources.show', ['troveKey' => $resource->slug], 301);
+        }
+    
+        return view('trove', ['resource' => $resource]);
+    })->name('resources.show');
 
     Route::get('/collections/{id}', function ($id) {
         $collection = Collection::where('id', $id)->where('public', 1)->firstOrFail();


### PR DESCRIPTION
This PR ensures that any previous style of url for a resource still works and redirects to the correct trove including:

- The ID instead of the slug of a current trove
- The ID or slug of an old trove that has since been updated / moved - these are listed in the troves.previous_slugs database column