### PR TITLE
Backend tweaks

### DIFF
--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -97,6 +97,7 @@ class CollectionResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->defaultSort('created_at', 'desc')
             ->columns([
                 Tables\Columns\TextColumn::make('title')
                     ->wrap(),

--- a/app/Filament/Resources/TagResource.php
+++ b/app/Filament/Resources/TagResource.php
@@ -51,8 +51,9 @@ class TagResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->defaultSort('name->' . app()->getLocale())
             ->columns([
-                Tables\Columns\TextColumn::make('name'),
+                Tables\Columns\TextColumn::make('name')->searchable(),
                 Tables\Columns\TextColumn::make('tagType.label'),
                 Tables\Columns\TextColumn::make('troves_count')
                     ->label('# of troves')

--- a/app/Filament/Resources/TroveResource.php
+++ b/app/Filament/Resources/TroveResource.php
@@ -364,6 +364,7 @@ class TroveResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->defaultSort('created_at', 'desc')
             ->searchable()
             ->columns(static::getTableColumns())
             ->filters(static::getTableFilters())


### PR DESCRIPTION
This PR updates the admin panel:
- make tags searchable and sorted alphabetically by default
- sorts troves and collections by the lates added first