### PR TITLE
Increases search limit

### DIFF
--- a/app/Livewire/BrowseAll.php
+++ b/app/Livewire/BrowseAll.php
@@ -6,11 +6,14 @@ use App\Models\Tag;
 use App\Models\Trove;
 use Livewire\Component;
 use App\Models\Collection;
+use App\Traits\UsesCustomSearchOptions;
 use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class BrowseAll extends Component
 {
+    use UsesCustomSearchOptions;
+    
     public ?string $query = null;
     public EloquentCollection $resources;
     public EloquentCollection $collections;
@@ -48,7 +51,7 @@ class BrowseAll extends Component
         // Fetch Resources (Trove)
         $resourceQuery = Trove::query()->where('is_published', 1);
         if (!empty($this->query)) {
-            $searchResults = Trove::search($this->query)->get();
+            $searchResults = Trove::search($this->query, $this->getSearchWithOptions())->get();
             $resourceQuery->whereIn('id', $searchResults->pluck('id'));
         }
         if (!empty($this->selectedResearchMethods)) {
@@ -64,7 +67,7 @@ class BrowseAll extends Component
         // Fetch Collections
         $collectionQuery = Collection::where('public', 1);
         if (!empty($this->query)) {
-            $searchResults = Collection::search($this->query)->get();
+            $searchResults = Collection::search($this->query, $this->getSearchWithOptions())->get();
             $collectionQuery->whereIn('id', $searchResults->pluck('id'));
         }
         if (!empty($this->selectedLanguages)) {

--- a/app/Livewire/Collections.php
+++ b/app/Livewire/Collections.php
@@ -4,10 +4,13 @@ namespace App\Livewire;
 
 use Livewire\Component;
 use App\Models\Collection;
+use App\Traits\UsesCustomSearchOptions;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class Collections extends Component
 {
+    use UsesCustomSearchOptions;
+    
     public ?string $query = null;
     public EloquentCollection $collections;
     public int $totalCollections;
@@ -36,7 +39,7 @@ class Collections extends Component
         
             // Step 2: Apply search term if there's a query
             if (!empty($this->query)) {
-                $collectionResults = Collection::search($this->query)->get();
+                $collectionResults = Collection::search($this->query, $this->getSearchWithOptions())->get();
                 if ($collectionResults->isNotEmpty()) {
                     $collectionIds = $collectionResults->pluck('id');
                     $collectionsQuery->whereIn('id', $collectionIds);

--- a/app/Livewire/Resources.php
+++ b/app/Livewire/Resources.php
@@ -5,10 +5,13 @@ namespace App\Livewire;
 use App\Models\Tag;
 use App\Models\Trove;
 use Livewire\Component;
+use App\Traits\UsesCustomSearchOptions;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 
 class Resources extends Component
 {
+    use UsesCustomSearchOptions;
+    
     public ?string $query = null;
     public EloquentCollection $resources;
     public int $totalResources = 0;
@@ -53,7 +56,7 @@ class Resources extends Component
             // Step 4: Apply search term if there's a query
             // Step 5: Retrieve filtered troves
             if (!empty($this->query)) {
-                $searchResults = Trove::search($this->query)->get();
+                $searchResults = Trove::search($this->query, $this->getSearchWithOptions())->get();
                 if ($searchResults->isNotEmpty()) {
                     $ids = $searchResults->pluck('id');
                     $query->whereIn('id', $ids);

--- a/app/Traits/UsesCustomSearchOptions.php
+++ b/app/Traits/UsesCustomSearchOptions.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Traits;
+
+trait UsesCustomSearchOptions
+{
+    public function getSearchWithOptions(): \Closure
+    {
+        return function ($meiliSearch, $query, array $options = []) {
+            $options['hitsPerPage'] = (int) config('scout.scout_search_limit', 500);
+            return $meiliSearch->search($query, $options);
+        };
+    }
+}


### PR DESCRIPTION
This PR increases the default Meilisearch result limit by creating a reusable trait UsesCustomSearchOptions that customises the search options. This trait is applied in the Livewire components to override the default limit of 20.