### PR TITLE
Optimise image size for results; paginate browse-all page

### DIFF
--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -42,7 +42,14 @@ class Collection extends Model implements HasMedia
     protected function coverImage(): Attribute
     {
         return new Attribute(
-            get: fn ()  => $this->getMedia("cover_image_" . app()->getLocale())->first()?->getUrl() ?? asset('images/default-cover-photo.jpg')
+            get: fn() => $this->getFirstMediaUrl('cover_image_' . app()->getLocale()) ?? asset('images/default-cover-photo.jpg')
+        );
+    }
+
+    protected function coverImageThumb(): Attribute
+    {
+        return new Attribute(
+            get: fn() => $this->getFirstMediaUrl('cover_image_' . app()->getLocale(), 'cover_thumb') ?? asset('images/default-cover-photo.jpg')
         );
     }
 
@@ -67,9 +74,9 @@ class Collection extends Model implements HasMedia
         return Collection::whereHas('troves', function ($query) {
             $query->whereIn('collection_trove.trove_id', $this->troves->pluck('id'));
         })
-        ->where('id', '!=', $this->id) // Exclude itself
-        ->distinct()
-        ->get();
+            ->where('id', '!=', $this->id) // Exclude itself
+            ->distinct()
+            ->get();
     }
 
 

--- a/app/Models/Trove.php
+++ b/app/Models/Trove.php
@@ -3,32 +3,31 @@
 namespace App\Models;
 
 use Carbon\Carbon;
-use App\Models\Tag;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 use Laravel\Scout\Searchable;
-use Spatie\MediaLibrary\HasMedia;
-use Illuminate\Database\Eloquent\Model;
-use Spatie\Translatable\HasTranslations;
-use Spatie\MediaLibrary\InteractsWithMedia;
-use Spatie\MediaLibrary\Support\MediaStream;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use \Oddvalue\LaravelDrafts\Concerns\HasDrafts;
-use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Spatie\MediaLibrary\MediaCollections\MediaCollection;
+use Oddvalue\LaravelDrafts\Concerns\HasDrafts;
 use Parallax\FilamentComments\Models\Traits\HasFilamentComments;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\MediaCollection;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Spatie\MediaLibrary\Support\MediaStream;
+use Spatie\Translatable\HasTranslations;
 
 class Trove extends Model implements HasMedia
 {
-    use HasFactory;
-    use InteractsWithMedia;
-    use HasTranslations;
     use HasDrafts;
+    use HasFactory;
     use HasFilamentComments;
+    use HasTranslations;
+    use InteractsWithMedia;
     use Searchable;
     use SoftDeletes;
 
@@ -76,7 +75,6 @@ class Trove extends Model implements HasMedia
 
         static::saving(function (Trove $trove) {
 
-
             // don't generate a slug if it already exists
             if ($trove->slug) {
                 return;
@@ -85,7 +83,7 @@ class Trove extends Model implements HasMedia
             // set the slug to the first available title locale
             $locales = $trove->getTranslatedLocales('title');
 
-            $trove->slug = Str::slug($trove->getTranslation('title', $locales[0])) . '-' . Carbon::now()->format('Y-m-d');
+            $trove->slug = Str::slug($trove->getTranslation('title', $locales[0])).'-'.Carbon::now()->format('Y-m-d');
 
             // check for uniqueness and append a number if necessary
             $uniquenessQuery = Trove::withTrashed()
@@ -99,9 +97,8 @@ class Trove extends Model implements HasMedia
             $count = $uniquenessQuery->count();
 
             if ($count > 0) {
-                $trove->slug = $trove->slug . '-' . $count;
+                $trove->slug = $trove->slug.'-'.$count;
             }
-
 
         });
 
@@ -113,18 +110,36 @@ class Trove extends Model implements HasMedia
         foreach (config('app.locales') as $key => $locale) {
             $this->addMediaCollection("cover_image_{$key}")
                 ->singleFile();
-
             $this->addMediaCollection("content_{$key}");
         }
+    }
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $collections = [];
+        foreach (config('app.locales') as $key => $locale) {
+            $collections[] = "cover_image_{$key}";
+        }
+
+        $this->addMediaConversion('cover_thumb')
+            ->width(450)
+            ->performOnCollections(...$collections);
+
     }
 
     protected function coverImage(): Attribute
     {
         return new Attribute(
-            get: fn ()  => $this->getMedia("cover_image_" . app()->getLocale())->first()?->getUrl() ?? asset('images/default-cover-photo.jpg')
+            get: fn () => $this->getFirstMediaUrl('cover_image_'.app()->getLocale()) ?? asset('images/default-cover-photo.jpg')
         );
     }
 
+    protected function coverImageThumb(): Attribute
+    {
+        return new Attribute(
+            get: fn() => $this->getFirstMediaUrl('cover_image_'.app()->getLocale(), 'cover_thumb') ?? asset('images/default-cover-photo.jpg')
+        );
+    }
 
     public function user(): BelongsTo
     {
@@ -175,10 +190,9 @@ class Trove extends Model implements HasMedia
     public function hasPublishedVersion(): Attribute
     {
         return new Attribute(
-            get: fn() => $this->revisions()->where('is_published', true)->exists()
+            get: fn () => $this->revisions()->where('is_published', true)->exists()
         );
     }
-
 
     // Matching the old Algolia serachable array as much as possible
     public function toSearchableArray(): array
@@ -205,7 +219,7 @@ class Trove extends Model implements HasMedia
         $array['languages']['name']['en'] = $languages;
 
         foreach (TagType::all() as $tagType) {
-            $array[strtolower($tagType->label)] = $this->tags->where('type_id', $tagType->id)->map(fn($tag) => [
+            $array[strtolower($tagType->label)] = $this->tags->where('type_id', $tagType->id)->map(fn ($tag) => [
                 'name' => [
                     'en' => $tag->getTranslation('name', 'en'),
                     'es' => $tag->getTranslation('name', 'es'),
@@ -214,9 +228,8 @@ class Trove extends Model implements HasMedia
             ])->values()->toArray();
         }
 
-
         $array['resourceTypes'] = $this->troveTypes
-            ->map(fn(TroveType $type) => [
+            ->map(fn (TroveType $type) => [
                 'name' => [
                     'en' => $type->getTranslation('label', 'en'),
                     'es' => $type->getTranslation('label', 'es'),
@@ -225,14 +238,13 @@ class Trove extends Model implements HasMedia
             ])->values()->toArray();
 
         $array['collections']['id'] = $this->collections->pluck('id');
-        $array['tags'] = $this->tags->map(fn($tag) => [
+        $array['tags'] = $this->tags->map(fn ($tag) => [
             'name' => [
                 'en' => $tag->getTranslation('name', 'en'),
                 'es' => $tag->getTranslation('name', 'es'),
                 'fr' => $tag->getTranslation('name', 'fr'),
             ],
         ])->values()->toArray();
-
 
         $array['cover_image'] = $this->getFirstMediaUrl('cover_image_en');
 
@@ -252,7 +264,7 @@ class Trove extends Model implements HasMedia
         $locale = app()->getLocale();
 
         // Get the media collection name
-        $collectionName = 'content_' . $locale;
+        $collectionName = 'content_'.$locale;
 
         // Get all media files for this locale
         $troveFiles = $this->getMedia($collectionName);
@@ -263,7 +275,7 @@ class Trove extends Model implements HasMedia
         }
 
         // Return the ZIP of all files
-        $filename = Str::slug($this->title) . "-{$locale}-files.zip";
+        $filename = Str::slug($this->title)."-{$locale}-files.zip";
 
         return MediaStream::create($filename)->addMedia($troveFiles);
     }
@@ -274,31 +286,38 @@ class Trove extends Model implements HasMedia
         $trove = self::where('slug', $troveKey)
             ->where('is_published', 1)
             ->first();
-        if ($trove) return $trove;
+        if ($trove) {
+            return $trove;
+        }
 
         // Try id
         if (is_numeric($troveKey)) {
-            $trove = self::where('id', (int)$troveKey)
+            $trove = self::where('id', (int) $troveKey)
                 ->where('is_published', 1)
                 ->first();
-            if ($trove) return $trove;
+            if ($trove) {
+                return $trove;
+            }
         }
 
         // Try previous_slugs (string)
-        $trove = self::whereJsonContains('previous_slugs', (string)$troveKey)
+        $trove = self::whereJsonContains('previous_slugs', (string) $troveKey)
             ->where('is_published', 1)
             ->first();
-        if ($trove) return $trove;
+        if ($trove) {
+            return $trove;
+        }
 
         // Try previous_slugs (numeric)
         if (is_numeric($troveKey)) {
-            $trove = self::whereJsonContains('previous_slugs', (int)$troveKey)
+            $trove = self::whereJsonContains('previous_slugs', (int) $troveKey)
                 ->where('is_published', 1)
                 ->first();
-            if ($trove) return $trove;
+            if ($trove) {
+                return $trove;
+            }
         }
 
         return null;
     }
-
 }

--- a/resources/views/components/collection-result-card.blade.php
+++ b/resources/views/components/collection-result-card.blade.php
@@ -8,7 +8,7 @@
        target="_blank"></a>
     <div class="flex flex-col justify-start">
         <div class="h-52 bg-cover bg-center mb-4 overflow-y-hidden">
-            <img src="{{ $item['cover_image'] }}" class="overflow-y-hidden card-img w-full"/>
+            <img src="{{ $item['cover_image_thumb'] }}" class="overflow-y-hidden card-img w-full"/>
         </div>
         <div class="absolute top-4 left-4 h-12 w-12  rounded-full text-white text-center py-auto bg-stats4sd-red">
             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="white" class="mx-auto my-3">

--- a/resources/views/components/resource-result-card.blade.php
+++ b/resources/views/components/resource-result-card.blade.php
@@ -8,7 +8,7 @@
        target="_blank"></a>
     <div class="flex flex-col justify-start">
         <div class="h-52 bg-cover bg-center mb-4 overflow-y-hidden">
-            <img src="{{ $item['cover_image'] }}" class="overflow-y-hidden card-img w-full"/>
+            <img src="{{ $item['cover_image_thumb'] }}" class="overflow-y-hidden card-img w-full"/>
         </div>
         <div class="absolute top-4 left-4 h-12 w-12  rounded-full text-white text-center py-auto bg-black">
             <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="white" class="mx-auto my-3">

--- a/resources/views/livewire/browse-all.blade.php
+++ b/resources/views/livewire/browse-all.blade.php
@@ -35,14 +35,14 @@
 
                     <div class="absolute left-3 top-1/2 transform -translate-y-1/2">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="3" stroke="currentColor" class="w-5 h-5 text-gray-600">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/>
                         </svg>
                     </div>
 
                     <!-- Clear Button -->
                     @if($query)
                         <svg xmlns="http://www.w3.org/2000/svg" wire:click="clearSearch" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="gray" class="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 cursor-pointer hover:stroke-gray-700 transition-colors duration-200">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
                         </svg>
                     @endif
                 </div>
@@ -53,20 +53,20 @@
                     <div class="flex justify-between items-center cursor-pointer" @click="openLanguage = !openLanguage">
                         <label class="text-base font-bold">{{ t("Language:") }}</label>
                         <svg class="w-5 h-5 transition-transform duration-300" :class="openLanguage ? 'rotate-90' : 'rotate-0'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
                         </svg>
                     </div>
                     <div class="space-y-2 mt-2 text-sm" x-show="openLanguage" x-show>
                         <label class="flex items-center">
-                            <input type="checkbox" wire:model="selectedLanguages" value="es" wire:change="search" class="mr-2 accent-stats4sd-red" />
+                            <input type="checkbox" wire:model="selectedLanguages" value="es" wire:change="search" class="mr-2 accent-stats4sd-red"/>
                             {{ t("Spanish") }}
                         </label>
                         <label class="flex items-center">
-                            <input type="checkbox" wire:model="selectedLanguages" value="en" wire:change="search" class="mr-2 accent-stats4sd-red" />
+                            <input type="checkbox" wire:model="selectedLanguages" value="en" wire:change="search" class="mr-2 accent-stats4sd-red"/>
                             {{ t("English") }}
                         </label>
                         <label class="flex items-center">
-                            <input type="checkbox" wire:model="selectedLanguages" value="fr" wire:change="search" class="mr-2 accent-stats4sd-red" />
+                            <input type="checkbox" wire:model="selectedLanguages" value="fr" wire:change="search" class="mr-2 accent-stats4sd-red"/>
                             {{ t("French") }}
                         </label>
                     </div>
@@ -78,7 +78,7 @@
                     <div class="flex justify-between items-center cursor-pointer" @click="openMethods = !openMethods">
                         <label class="text-base font-bold">{{ t("Research method:") }}</label>
                         <svg class="w-5 h-5 transition-transform duration-300" :class="openMethods ? 'rotate-90' : 'rotate-0'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
                         </svg>
                     </div>
                     <div class="flex flex-col space-y-2 mt-2 text-sm" x-show="openMethods" x-show>
@@ -97,7 +97,7 @@
                     <div class="flex justify-between items-center cursor-pointer" @click="openTopics = !openTopics">
                         <label class="text-base font-bold">{{ t("Topic:") }}</label>
                         <svg class="w-5 h-5 transition-transform duration-300" :class="openTopics ? 'rotate-90' : 'rotate-0'" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
                         </svg>
                     </div>
                     <div class="flex flex-col space-y-2 mt-2 text-sm" x-show="openTopics" x-show>
@@ -115,7 +115,7 @@
             <!-- Resources and Collections Cards -->
             <div class="w-3/4">
                 <div class="p-8">
-                    {{ t("Showing ") . $totalResourcesAndCollections . t(" resources and collections") }}
+                    {{ t("Showing ") . $renderedResourcesAndCollections . ' out of ' . $totalResourcesAndCollections . t(" resources and collections") }}
                     @if($query || !empty($selectedLanguages) || !empty($selectedResearchMethods))
                         <button wire:click="clearFilters" class="text-gray-500 hover:text-gray-700 underline text-sm">
                             {{ t("Clear Filters") }}
@@ -125,13 +125,26 @@
 
                 <div id="Items-content" class="py-8 px-2 sm:px-4 rounded-lg">
                     <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8 max-w-6xl mx-auto">
-                        @foreach ($this->items as $index => $item)
+                        @foreach ($this->renderedItems as $index => $item)
                             @if($item['type'] === 'resource')
                                 <x-resource-result-card :item="$item"/>
                             @elseif($item['type'] === 'collection')
                                 <x-collection-result-card :item="$item"/>
                             @endif
                         @endforeach
+
+                        <div class="flex flex-col justify-end align-middle">
+                            @if($renderedResourcesAndCollections < $totalResourcesAndCollections)
+
+                                <button wire:click="loadNextPage" class="text-white text-center py-2 px-8 rounded-full bg-stats4sd-red my-auto mx-auto h-20">
+                                    {{ t("Load More...") }}
+                                </button>
+                            @else
+                                <button class="text-black text-center py-2 px-8 rounded-full bg-gray-300 my-auto mx-auto h-20" disabled="disabled">
+                                    No more results found
+                                </button>
+                            @endif
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #65; fixes #64.


This PR adds a media conversion for cover images, which creates a version of each cover image with a width of 450px. This is large enough to render at full resolution on the results cards regardless of screen size. 


It also optimises the browse-all page by adding custom pagination. I used a custom approach because the results are merged from 2 separate queries, so using built-in pagination would have been complicated. 

The page now loads 100 results to start, and loads another 100 results each time the user clicks the "load more" button, located at the end of the results cards. 

The load more button appears centred in the card space 1 after the final result.

> [!NOTE]
> Not sure if the "load more" button should be in a "card-sized space" when it's on a row on it's own (3rd screenshot)? (i.e. should it add the height of another full row of cards? 
 
---
### Screenshots:

<img width="1404" height="1387" alt="CleanShot 2025-07-16 at 13 50 14" src="https://github.com/user-attachments/assets/c759081a-e3a3-46c0-9a57-b320f949ac0e" />

<img width="1405" height="1392" alt="CleanShot 2025-07-16 at 13 50 02" src="https://github.com/user-attachments/assets/833ed31d-5f6a-4d83-8488-167a7ee161af" />

<img width="1404" height="1389" alt="CleanShot 2025-07-16 at 13 50 23" src="https://github.com/user-attachments/assets/32cc0d43-861f-4c2c-99e5-d1e8e2e53033" />


---

When all results are loaded, a notice appears as so: 

<img width="1404" height="1392" alt="CleanShot 2025-07-16 at 13 51 17" src="https://github.com/user-attachments/assets/181829c7-2501-4e16-a11c-5fd44a40f20b" />
