### PR TITLE
adds fallback for cover image thumbnail

### DIFF
--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -49,7 +49,35 @@ class Collection extends Model implements HasMedia
     protected function coverImageThumb(): Attribute
     {
         return new Attribute(
-            get: fn() => $this->getFirstMediaUrl('cover_image_' . app()->getLocale(), 'cover_thumb') ?? asset('images/default-cover-photo.jpg')
+            get: function () {
+                $currentLocale = app()->getLocale();
+
+                // 1. Check current locale
+                $url = $this->getFirstMediaUrl('cover_image_'.$currentLocale, 'cover_thumb');
+                if ($url) {
+                    return $url;
+                }
+
+                // 2. Fallback to English
+                if ($currentLocale !== 'en') {
+                    $url = $this->getFirstMediaUrl('cover_image_en', 'cover_thumb');
+                    if ($url) {
+                        return $url;
+                    }
+                }
+
+                // 3. Fallback to the other locale
+                $otherLocale = collect(['es', 'fr'])
+                    ->first(fn($locale) => $locale !== $currentLocale);
+
+                if ($otherLocale) {
+                    $url = $this->getFirstMediaUrl('cover_image_'.$otherLocale, 'cover_thumb');
+                    if ($url) {
+                        return $url;
+                    }
+                }
+
+            }
         );
     }
 

--- a/app/Models/Trove.php
+++ b/app/Models/Trove.php
@@ -137,7 +137,35 @@ class Trove extends Model implements HasMedia
     protected function coverImageThumb(): Attribute
     {
         return new Attribute(
-            get: fn() => $this->getFirstMediaUrl('cover_image_'.app()->getLocale(), 'cover_thumb') ?? asset('images/default-cover-photo.jpg')
+            get: function () {
+                $currentLocale = app()->getLocale();
+
+                // 1. Check current locale
+                $url = $this->getFirstMediaUrl('cover_image_'.$currentLocale, 'cover_thumb');
+                if ($url) {
+                    return $url;
+                }
+
+                // 2. Fallback to English
+                if ($currentLocale !== 'en') {
+                    $url = $this->getFirstMediaUrl('cover_image_en', 'cover_thumb');
+                    if ($url) {
+                        return $url;
+                    }
+                }
+
+                // 3. Fallback to the other locale
+                $otherLocale = collect(['es', 'fr'])
+                    ->first(fn($locale) => $locale !== $currentLocale);
+
+                if ($otherLocale) {
+                    $url = $this->getFirstMediaUrl('cover_image_'.$otherLocale, 'cover_thumb');
+                    if ($url) {
+                        return $url;
+                    }
+                }
+
+            }
         );
     }
 


### PR DESCRIPTION
Since cover images are uploaded per language, this PR adds a fallback to display a cover image from another language if one is not available for the current locale.