### PR TITLE
Updates rendering of youtube to only show vide on non-null youtube_id

### DIFF
--- a/resources/views/trove.blade.php
+++ b/resources/views/trove.blade.php
@@ -111,7 +111,7 @@
         <!-- Embedded Youtube Video -->
         <div class="pb-8">
 
-            @if ($resource->youtube_links)
+            @if ($resource->getTranslation('youtube_links', app()->getLocale())[0]['youtube_id'] ?? null)
 
                 @php
 


### PR DESCRIPTION
Because of the way the trove creation form is now set, all new troves have a non-null `youtube_links` value. So we need to check the nested `youtube_id` value to determine if we render the section or not. 